### PR TITLE
Turn off csrf for static app pages

### DIFF
--- a/app/controllers/subdomains_controller.rb
+++ b/app/controllers/subdomains_controller.rb
@@ -3,13 +3,12 @@ class SubdomainsController < ApplicationController
 
   VALID_CHARACTERS = "a-zA-Z0-9~!@$%^&*()#`_+-=<>\"{}|[];',?".freeze
 
+  skip_before_action :verify_authenticity_token
   before_filter :set_app
 
   def show
     if file && file.exist?
-      render inline: File.read(file),
-             status: 200,
-             layout: false
+      send_file file, disposition: 'inline'
     else
       not_found!
     end


### PR DESCRIPTION
We can safely turn off csrf protection here since we are serving only static pages, no server side processing is made. What is more I improved a bit show method - not content types should be set correctly basing on file extension.

/cc @mpawlik please take a look

Fixes #10