### PR TITLE
Nprogress for loading page state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'turbolinks'
 gem 'bootstrap-sass', '~> 3.3.1'
 gem 'font-awesome-sass', '~> 4.3.0'
 gem 'autoprefixer-rails'
+gem 'nprogress-rails'
 
 gem 'haml-rails'
 gem 'simple_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
     notiffany (0.0.6)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    nprogress-rails (0.1.6.6)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
@@ -326,6 +327,7 @@ DEPENDENCIES
   jquery-rails
   jquery-turbolinks
   newrelic_rpm
+  nprogress-rails
   omniauth-openid
   pg
   puma

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -15,6 +15,8 @@
 #= require jquery_ujs
 #= require turbolinks
 #= require bootstrap-sprockets
+#= require nprogress
+#= require nprogress-turbolinks
 #= require_tree .
 
 $ ->

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,18 +13,18 @@
  *= require_self
  */
 
- @import "bootswatch/variables";
+@import "bootswatch/variables";
 
- @import "bootstrap";
- @import "bootstrap-sprockets";
+@import "bootstrap";
+@import "bootstrap-sprockets";
 
- @import "font-awesome-sprockets";
- @import "font-awesome";
+@import "font-awesome-sprockets";
+@import "font-awesome";
 
- @import "bootswatch/bootswatch";
+@import "bootswatch/bootswatch";
 
- @import "generic/*";
- @import "sections/*";
+@import "nprogress";
+@import "nprogress-bootstrap";
 
-
-
+@import "generic/*";
+@import "sections/*";

--- a/app/assets/stylesheets/bootswatch/_variables.scss
+++ b/app/assets/stylesheets/bootswatch/_variables.scss
@@ -855,3 +855,6 @@ $page-header-border-color:    $gray-lighter;
 $dl-horizontal-offset:        $component-offset-horizontal;
 //** Horizontal line color.
 $hr-border:                   $gray-lighter;
+
+//== nprogress
+$nprogress-color:             $brand-danger;

--- a/app/assets/stylesheets/generic/nprogress.scss
+++ b/app/assets/stylesheets/generic/nprogress.scss
@@ -1,0 +1,3 @@
+#nprogress .spinner {
+  top: 20px;
+}


### PR DESCRIPTION
When turbolinks are used not progress (spinning wheel) is visible in the browser tab. nprogress adds such spinning wheel into application. It is similar like in youtube.

![plgapp_nprogress](https://cloud.githubusercontent.com/assets/1265430/6440120/26b41912-c0da-11e4-9eb7-104c692c6299.png)

Color of spinning wheel can be customized by changing value of `$nprogress-color` variable in `bootswatch/_variables.scss`