### PR TITLE
Fix session creation race condition

### DIFF
--- a/app/controllers/subdomains_controller.rb
+++ b/app/controllers/subdomains_controller.rb
@@ -5,6 +5,10 @@ class SubdomainsController < ApplicationController
   before_filter :set_app, :app_authorize!
 
   def show
+    unless session[:_csrf_token]
+      form_authenticity_token
+    end
+
     if file && file.exist?
       send_file file, disposition: 'inline'
     else


### PR DESCRIPTION
When 2 requests are made in the same time than 2 session objects are created. As a conclusion 2 csrf_tokens are generated. This commit fixed this problem by creating session object when first app page is served.