### PR TITLE
Add hack to make plgdata upload works

### DIFF
--- a/lib/proxy/plgdata.rb
+++ b/lib/proxy/plgdata.rb
@@ -8,6 +8,12 @@ module Proxy
       super(proxy, Rails.configuration.constants['plgdata'])
     end
 
+    def rewrite_env(env)
+      super.tap do |e|
+        e['HTTP_ACCEPT'] = "*/*" if e['PATH_INFO'].start_with?('/upload')
+      end
+    end
+
     protected
 
     def path(env)


### PR DESCRIPTION
It seems like Accept header:

```
text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
```

is not valid for plgdata. Changing it into `*/*` only for upload do the trick. We should talk with plgdata author and make it work with original content type - then this hack can be removed.