### PR TITLE
Use redis for cache and session store.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem 'dropbox-sdk'
 gem 'sidekiq'
 gem 'sinatra', require: nil
 
+gem 'redis-rails'
+
 group :development, :test do
   gem 'byebug'
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,8 +229,24 @@ GEM
       ffi (>= 0.5.0)
     redcarpet (3.2.3)
     redis (3.2.1)
+    redis-actionpack (4.0.0)
+      actionpack (~> 4)
+      redis-rack (~> 1.5.0)
+      redis-store (~> 1.1.0)
+    redis-activesupport (4.0.0)
+      activesupport (~> 4)
+      redis-store (~> 1.1.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    redis-rack (1.5.0)
+      rack (~> 1.5)
+      redis-store (~> 1.1.0)
+    redis-rails (4.0.0)
+      redis-actionpack (~> 4)
+      redis-activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-store (1.1.4)
+      redis (>= 2.2)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rspec (3.2.0)
@@ -361,6 +377,7 @@ DEPENDENCIES
   rack-proxy
   rails (= 4.2.1)
   redcarpet
+  redis-rails
   rspec-rails (~> 3.0)
   ruby-openid (~> 2.7.0)
   rubyzip

--- a/app/controllers/concerns/proxyable.rb
+++ b/app/controllers/concerns/proxyable.rb
@@ -18,7 +18,7 @@ module Proxyable
   private
 
   def proxy
-    proxy_class.new(current_user.proxy, params)
+    proxy_class.new(session['proxy'], params)
   end
 
   def proxy_responce

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,6 +6,7 @@ module Users
       @user = User.from_plgrid_omniauth(auth)
 
       if @user.persisted?
+        session['proxy'] = proxy(auth.info)
         sign_in_and_redirect @user, event: :authentication
         if is_navigational_format?
           set_flash_message(:notice, :success, kind: 'open_id')
@@ -17,6 +18,10 @@ module Users
     end
 
     private
+
+    def proxy(info)
+      info.proxy + info.proxyPrivKey + info.userCert
+    end
 
     def auth
       @auth ||= env['omniauth.auth']

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,6 @@ class User < ActiveRecord::Base
       info = auth.info
       user.email = info.email
       user.name = info.name
-      user.proxy = info.proxy + info.proxyPrivKey + info.userCert
 
       user.save
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,16 @@ module Plgapp
 
     config.dropbox = Struct.new(:app_key, :app_secret).
       new(ENV['DROPBOX_APP_KEY'], ENV['DROPBOX_APP_SECRET'])
+
+    redis_url_string = config.constants['redis_url'] || 'redis://localhost:6379'
+
+    # Redis::Store does not handle Unix sockets well, so let's do it for them
+    redis_config_hash = Redis::Store::Factory.
+                        extract_host_options_from_uri(redis_url_string)
+    redis_uri = URI.parse(redis_url_string)
+    redis_config_hash[:path] = redis_uri.path if redis_uri.scheme == 'unix'
+
+    redis_config_hash[:namespace] = 'cache:plgapp'
+    config.cache_store = :redis_store, redis_config_hash
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,15 +1,16 @@
 # Be sure to restart your server when you modify this file.
-
-if Rails.env.production?
-  Rails.application.config.session_store :cookie_store,
-                                         key: '_plgapp_session',
-                                         expire_after: 40.minutes
+#
+if Rails.env.test?
+  Rails.application.config.
+    session_store(:cookie_store, key: '_plgapp_session')
 else
-  Rails.application.config.session_store :cookie_store,
-                                         key: '_plgapp_session'
-end
-
-# Clearing user proxy from DB on logout, if session still exists
-Warden::Manager.before_logout do |user, auth, opts|
-  user.clear_proxy if user
+  Rails.application.config.
+    session_store(:redis_store,
+                  # re-use the Redis config from the Rails cache store
+                  servers: Plgapp::Application.config.
+                           cache_store[1].merge(namespace: 'session:plgapp'),
+                  key: '_plgapp_session',
+                  secure: true,
+                  httponly: true,
+                  expire_after: 40.minutes)
 end

--- a/db/migrate/20150519084036_remove_user_proxy.rb
+++ b/db/migrate/20150519084036_remove_user_proxy.rb
@@ -1,0 +1,5 @@
+class RemoveUserProxy < ActiveRecord::Migration
+  def change
+    remove_column :users, :proxy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150408124959) do
+ActiveRecord::Schema.define(version: 20150519084036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,7 +71,6 @@ ActiveRecord::Schema.define(version: 20150408124959) do
     t.inet     "last_sign_in_ip"
     t.string   "login",                                null: false
     t.string   "name",                 default: "",    null: false
-    t.text     "proxy"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "dropbox_user"

--- a/spec/features/user_authentication_spec.rb
+++ b/spec/features/user_authentication_spec.rb
@@ -20,23 +20,4 @@ RSpec.feature 'User authentication' do
 
     expect(page).not_to have_content user.name
   end
-
-  scenario 'user has proxy' do
-    user = create(:user)
-
-    sign_in_as(user)
-    user.reload
-
-    expect(user.proxy).to_not be_nil
-  end
-
-  scenario 'user proxy is cleared after signs out' do
-    user = create(:user)
-
-    sign_in_as(user)
-    find(:linkhref, '/sign_out').click
-    user.reload
-
-    expect(user.proxy).to be_nil
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe User do
   it { should have_many(:activities).dependent(:nullify) }
 
   it 'creates new user while logging using omniauth' do
-      expect { User.from_plgrid_omniauth(auth) }.to change { User.count }.by(1)
-    end
+    expect { User.from_plgrid_omniauth(auth) }.to change { User.count }.by(1)
+  end
 
   it 'sets user details while logging using omniauth' do
     user = User.from_plgrid_omniauth(auth)
@@ -15,7 +15,6 @@ RSpec.describe User do
     expect(user.login).to eq 'johndoe'
     expect(user.name).to eq 'John Doe'
     expect(user.email).to eq 'a@b.c'
-    expect(user.proxy).to eq 'abc'
   end
 
   it 'reuse user account' do
@@ -25,12 +24,7 @@ RSpec.describe User do
   end
 
   def auth
-    double 'auth',
-            info: double(email: 'a@b.c',
-                         name: 'John Doe',
-                         nickname: 'johndoe',
-                         proxy: 'a',
-                         userCert: 'c',
-                         proxyPrivKey: 'b')
+    double('auth',
+           info: double(email: 'a@b.c', name: 'John Doe', nickname: 'johndoe'))
   end
 end


### PR DESCRIPTION
User proxy is also stored in redis session store. This solves the problem when user is logged in into two domains and log out from one domain. As a result user proxy were cleared. Thanks to redis store proxy is correlated with concrete session.