### PR TITLE
Do not allow rack-proxy to mess with request.env

### DIFF
--- a/app/controllers/concerns/proxyable.rb
+++ b/app/controllers/concerns/proxyable.rb
@@ -4,9 +4,9 @@ module Proxyable
   def call
     self.response_body = proxy_responce.body
     self.status = proxy_responce.status
-    response.headers = {
+    response.headers = response.headers.merge(
       'Content-Type' => proxy_responce.headers['content-type'].join(',')
-    }
+    )
   end
 
   protected
@@ -22,6 +22,7 @@ module Proxyable
   end
 
   def proxy_responce
-    @proxy_response ||= ActionDispatch::Response.new(*proxy.call(request.env))
+    @proxy_response ||= ActionDispatch::Response.
+                        new(*proxy.call(request.env.dup))
   end
 end


### PR DESCRIPTION
When `request.env` was passed into `rack-proxy` object it was modified
and as a result set session cookie with updated expires date was not
send in `Set-Cookie` header. This is solved by duplicating
`request.env`.