### PR TITLE
Add session timeout callback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :test do
   gem 'spring-commands-rspec'
   gem 'capybara'
+  gem "show_me_the_cookies"
   gem 'factory_girl_rails', '~> 4.0'
   gem 'shoulda-matchers', require: false
   gem 'guard-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,8 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    show_me_the_cookies (2.6.0)
+      capybara (~> 2.0)
     sidekiq (3.3.4)
       celluloid (>= 0.16.0)
       connection_pool (>= 2.1.1)
@@ -382,6 +384,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sentry-raven
   shoulda-matchers
+  show_me_the_cookies
   sidekiq
   simple_form
   sinatra

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_filter :set_locale
+  before_filter :set_session_expiry
   before_action :authenticate_user!
 
   rescue_from CanCan::AccessDenied do |exception|
@@ -20,6 +21,13 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_session_expiry
+    session_length = Rails.application.config.session_options[:expire_after]
+    cookies['session_expiry'] = {
+      value: (Time.now + session_length).to_f
+    }
+  end
 
   def set_locale
     if language_change_necessary?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,7 +2,9 @@
 #
 if Rails.env.test?
   Rails.application.config.
-    session_store(:cookie_store, key: '_plgapp_session')
+    session_store(:cookie_store,
+                  key: '_plgapp_session',
+                  expire_after: 40.minutes)
 else
   Rails.application.config.
     session_store(:redis_store,

--- a/doc/js_libs.en.md
+++ b/doc/js_libs.en.md
@@ -84,6 +84,20 @@ In the production mode, however, the local server address will be omitted thus g
 </head>
 ```
 
+### Register callback for session expiration
+
+```
+    var before_timeout = 60;
+    plgapp.registerSessionTimeoutCallback(function(time_left){
+        console.log("session will exire in: " + time_left);
+    }, before_timeout);
+```
+
+`RegisterSessionTimeoutCallback` allows for registration of session expiration
+callbacks. User can supply a specified number of seconds, which will be
+ subtracted from timeout in order to fire the callback before the actual
+ expiration occurs.
+
 ### Error class
 
 plgapp js libs use custom error class.

--- a/doc/js_libs.pl.md
+++ b/doc/js_libs.pl.md
@@ -82,6 +82,21 @@ W trybie produkcyjnym adres lokalnego serwera będzie pominięty a końcowa tre�
 </head>
 ```
 
+### Rejestrowanie funkcji callback dla wygaśnięcia sesji
+
+```
+    var before_timeout = 60;
+    plgapp.registerSessionTimeoutCallback(function(time_left){
+        console.log("session will exire in: " + time_left);
+    }, before_timeout);
+```
+
+`RegisterSessionTimeoutCallback` pozwala na zarejestrowanie funkcji callback,
+ która będzie wywołana przed wygaśnięciem sesji. Użytkownik może podać
+  opcjonalny argument, którym jest okres czasu w sekundach, który zostanie
+  odjęty od opóźnienia i spowoduje wywołanie callbacku przed faktycznym
+  wygaśnięciem sesji.
+
 ### Typ błędu
 
 Biblioteki PLGApp używają własnego typu błędu, w każdej sytuacji gdzie

--- a/public/plgapp/plgapp.js
+++ b/public/plgapp/plgapp.js
@@ -62,7 +62,7 @@ var PlgApp = function () {
             url: baseLocation + 'info',
             success: function(data) {
             	var url;
-            	
+
             	if(csses !== null) {
 	            	for(var i = 0; i < csses.length; i++) {
 	            		url = (data.development ? developmentRootUrl : '') +
@@ -71,7 +71,7 @@ var PlgApp = function () {
 	            				'"/>');
 	            	}
             	}
-            	
+
             	if(javascripts !== null) {
 	            	for(var j = 0; j < javascripts.length; j++) {
 	            		url = (data.development ? developmentRootUrl : '') +
@@ -85,6 +85,11 @@ var PlgApp = function () {
         });
     };
 
+    this.registerSessionTimeoutCallback = function(timeoutCallback,
+                                                   secondsBeforeTimeout) {
+        setSessionTimeout(timeoutCallback, secondsBeforeTimeout);
+    };
+
     //utilities -> to be moved to prototype
     this.parseError = function (xhr, status, error) {
         var data = xhr.responseText;
@@ -93,6 +98,37 @@ var PlgApp = function () {
         } catch (err) {
         }
         return new AppError(status + ' ' + xhr.status + ' ' + error, data);
+    };
+
+    var setSessionTimeout = function(timeoutCallback, secondsBeforeTimeout) {
+        if(!secondsBeforeTimeout) {
+            secondsBeforeTimeout = 0;
+        }
+        var sessionExpiry = getCookie('session_expiry') * 1000;
+        var now = (new Date()).valueOf();
+        var timeout = sessionExpiry - now - secondsBeforeTimeout * 1000;
+        if(timeout <= 0) {
+            timeoutCallback((sessionExpiry - now)/1000);
+        } else {
+            setTimeout(function() {
+                setSessionTimeout(timeoutCallback, secondsBeforeTimeout);
+            }, timeout);
+        }
+    };
+
+    var getCookie = function (cname) {
+        var name = cname + '=';
+        var ca = document.cookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return null;
     };
 };
 

--- a/spec/features/session_expiry_info_spec.rb
+++ b/spec/features/session_expiry_info_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.feature 'Session expiry info' do
+  scenario 'supply expiry information' do
+    visit root_path
+
+    expiry_cookie = get_me_the_cookie('session_expiry')
+    expect(expiry_cookie).not_to be_nil
+    expect(expiry_cookie[:value]).to match(/[0-9\.]/)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,9 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
   config.include Devise::TestHelpers, type: :controller
+
+  # Include ShowMeTheCookies for retrieving cookies from Capybara.
+  config.include ShowMeTheCookies, type: :feature
 end
 
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
Changes include:
 * extra cookie value, "session_expiry" contains a timestamp of session validity
 * new registerSessionTimeoutCallback function in plgapp.js

ticket reference: https://jira.plgrid.pl/jira/browse/PLGAPP-29