### PR TITLE
Check if application exists before entering subdomain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_filter :set_locale
   before_filter :set_session_expiry
-  before_action :authenticate_user!
+  before_filter :authenticate_user!
 
   rescue_from CanCan::AccessDenied do |exception|
     redirect_to root_url, alert: exception.message

--- a/app/controllers/concerns/subdomainable.rb
+++ b/app/controllers/concerns/subdomainable.rb
@@ -1,6 +1,12 @@
 module Subdomainable
   extend ActiveSupport::Concern
 
+  included do
+    rescue_from ActiveRecord::RecordNotFound do
+      render 'errors/app_not_found', layout: 'errors', status: 404
+    end
+  end
+
   private
 
   def set_app

--- a/app/controllers/subdomains_controller.rb
+++ b/app/controllers/subdomains_controller.rb
@@ -2,7 +2,8 @@ class SubdomainsController < ApplicationController
   include Subdomainable
 
   skip_before_action :verify_authenticity_token
-  before_filter :set_app, :app_authorize!
+  prepend_before_filter :set_app
+  before_filter :app_authorize!
 
   def show
     unless session[:_csrf_token]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Users::SessionsController < Devise::SessionsController
   include Subdomainable
 
-  before_filter :set_app, only: :new, if: :subdomain?
+  prepend_before_filter :set_app, only: :new, if: :subdomain?
 end

--- a/app/views/errors/app_not_found.html.haml
+++ b/app/views/errors/app_not_found.html.haml
@@ -1,0 +1,4 @@
+%h1 404
+%h3= t('error_no_app.title')
+%hr
+%p= t('error_no_app.description', root: root_url(subdomain: Rails.configuration.constants['domain_prefix'])).html_safe

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -11,6 +11,9 @@ en:
   error_500:
     title: Internal server error.
     description: Internal server error occured. We are already notified about this situation and we will try to fix the problem ASAP.
+  error_no_app:
+    title: Application does not exist.
+    description: 'Selected application cannot be found, please got to <a href="%{root}">main webpage</a> to see list of registered applications.'
   errors:
     messages:
       wrong_size: "is the wrong size (should be %{file_size})"

--- a/config/locales/errors.pl.yml
+++ b/config/locales/errors.pl.yml
@@ -11,6 +11,9 @@ pl:
   error_500:
     title: Wewnętrzny bląd serwera.
     description: Wystąpił wewnętrzny błąd serwera. Zostaliśmy już poinformowani o problemie i pracujemy nad jego rozwiązaniem.
+  error_no_app:
+    title: Aplikacja nie istnieje
+    description: 'Rządana aplikacja nie istnieje, odwiedz <a href="%{root}">główną stronę</a> aby zobaczyć listę zarejestrowanych aplikacji.'
   errors:
     messages:
       wrong_size: "Zła wielkość (powinno być %{file_size})"


### PR DESCRIPTION
Dedicated error view is presented to the user when application
correlated with subdomain does not exist

Fixes #71