### PR TITLE
Turn off csrf for open id failure

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-    skip_before_filter :verify_authenticity_token, only: [:open_id]
+    skip_before_filter :verify_authenticity_token, only: [:open_id, :failure]
 
     def open_id
       @user = User.from_plgrid_omniauth(auth)


### PR DESCRIPTION
When conversation with openid does not go well user was redirected into `failure` devise controller method. Unfortunately plgrid open id is not able to redirect csrf token and this method requires it. It was solved by turned off authenticity token verify for `failure` method. We can do this since it does not do any modification on the server side, it is only redirecting user into login page.