### PR TITLE
Ignore symlinks from zip archive

### DIFF
--- a/lib/carrierwave/storage/app.rb
+++ b/lib/carrierwave/storage/app.rb
@@ -7,8 +7,10 @@ module CarrierWave
         tmp_dir = Dir.mktmpdir('plgapp')
         Zip::File.open(file.file) do |zipfile|
           zipfile.each do |f|
-            dest_file = ::File.expand_path(f.name, tmp_dir)
-            f.extract(dest_file)
+            unless f.symlink?
+              dest_file = ::File.expand_path(f.name, tmp_dir)
+              f.extract(dest_file)
+            end
           end
 
           FileUtils.rm_r(app_dir)


### PR DESCRIPTION
It is possible to upload zip archive with symlink and see e.g. /etc/passwd. This PR fixes this issue by ignoring smylinks during zip upload.