### PR TITLE
Don't use interpreter pid in downloaded zip file name

### DIFF
--- a/lib/carrierwave/storage/app.rb
+++ b/lib/carrierwave/storage/app.rb
@@ -61,11 +61,10 @@ module CarrierWave
       end
 
       def tmp_file_path
-        tmpfile = Tempfile.new(["#{app_dir.basename}-", '.zip'])
-        path = tmpfile.path
-        tmpfile.unlink
+        t = Time.now.strftime('%Y%m%d')
+        filename = "#{app_dir.basename}-#{t}-#{rand(0x100000000).to_s(36)}.zip"
 
-        path
+        File.join(Dir.tmpdir, filename)
       end
 
       def app_dir


### PR DESCRIPTION
It seems like `Dir::Tmpname.make_tmpname` is using `$$` while generating temp file name. Pid can be used in many security attacks. As a conclusion method responsible for generating zip file name was reimplemented.