### PR TITLE
Don't allow to create dropbox files above app directory

### DIFF
--- a/app/services/dropbox/operation.rb
+++ b/app/services/dropbox/operation.rb
@@ -1,7 +1,10 @@
 require 'dropbox_sdk'
+require 'clean_path'
 
 module Dropbox
   class Operation < AppService
+    include CleanPath
+
     def initialize(author, app, options = {})
       super(author, app)
       @app_member = app && app.app_members.find_by(user: author)
@@ -35,7 +38,7 @@ module Dropbox
     end
 
     def relative_to_local(path)
-      File.join(root_path, path)
+      File.join(root_path, clean_path(path))
     end
 
     def relative_to_remote(path)

--- a/app/services/dropbox/pull_service.rb
+++ b/app/services/dropbox/pull_service.rb
@@ -103,7 +103,7 @@ module Dropbox
 
     def remote_to_relative(path)
       @subdomain_count ||= app.subdomain.length + 2
-      path[@subdomain_count..-1] || '.'
+      clean_path(path[@subdomain_count..-1] || '.')
     end
 
     def delta

--- a/app/services/get_app_file_service.rb
+++ b/app/services/get_app_file_service.rb
@@ -1,5 +1,7 @@
+require 'clean_path'
+
 class GetAppFileService
-  VALID_CHARACTERS = "a-zA-Z0-9~!@$%^&*()#`_+-=<>\"{}|[];',?".freeze
+  include CleanPath
 
   def initialize(app, dev, path)
     @app = app
@@ -8,7 +10,7 @@ class GetAppFileService
   end
 
   def execute
-    file = Pathname.new(content_path).join(clean_path)
+    file = Pathname.new(content_path).join(clean_path(@path))
 
     if file.directory?
       index = file.join('index.html')
@@ -34,15 +36,6 @@ class GetAppFileService
 
   def user_apps_dir
     Rails.configuration.apps_dir
-  end
-
-  def clean_path
-    path = Pathname.new("/#{clean_id}")
-    path.cleanpath.to_s[1..-1]
-  end
-
-  def clean_id
-    (@path || '').tr("^#{VALID_CHARACTERS}", '')
   end
 
   def dev?

--- a/lib/clean_path.rb
+++ b/lib/clean_path.rb
@@ -1,0 +1,8 @@
+module CleanPath
+  VALID_CHARACTERS = "a-zA-Z0-9~!@$%^&*()#`_+-=<>\"{}|[];',?".freeze
+
+  def clean_path(path)
+    valid_chars_path = (path || '').tr("^#{VALID_CHARACTERS}", '')
+    Pathname.new("/#{valid_chars_path}").cleanpath.to_s[1..-1]
+  end
+end

--- a/spec/services/dropbox/pull_service_spec.rb
+++ b/spec/services/dropbox/pull_service_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe Dropbox::PullService do
     expect(app_member.dropbox_entries.count).to eq 0
   end
 
+  it 'reject delete files above app directory' do
+    create_dev_file(app, 'file.txt', 'foo')
+    file_entry('file.txt')
+
+    expect_delta(["/#{app.subdomain}/../file.txt", nil])
+
+    service.execute
+
+    expect(File.exist?(path('file.txt'))).to be_falsy
+  end
+
   it 'creates new files' do
     expect_delta(
       [
@@ -87,6 +98,25 @@ RSpec.describe Dropbox::PullService do
     expect(sub.is_dir).to be_truthy
     expect(sub.revision).to eq '3'
     expect(sub.path).to eq 'sub'
+  end
+
+  it 'reject create files above app directory' do
+    expect_delta(
+      [
+        "/#{app.subdomain}/../file.txt",
+        {
+          'rev' => '1',
+          'path' => "/#{app.subdomain}/../file.txt",
+          'is_dir' => false,
+          'revision' => 24
+        }
+      ]
+    )
+    expect_get_file("/#{app.subdomain}/../file.txt", 'foo')
+
+    service.execute
+
+    expect(File.read(path('file.txt'))).to eq 'foo'
   end
 
   it 'updates files' do


### PR DESCRIPTION
Files `../../../dropbox/was_here` are converted into `dropbox/was_here` while creating, updating and removing files from dopbox.