### PR TITLE
Reject dropbox app root directory

### DIFF
--- a/app/services/dropbox/pull_service.rb
+++ b/app/services/dropbox/pull_service.rb
@@ -18,9 +18,11 @@ module Dropbox
     end
 
     def create_or_update(to_create)
-      to_create.each do |props|
-        props[:is_dir] ? create_update_dir(props) : create_update_file(props)
-      end
+      to_create.
+        select { |p| p[:path].present? }.
+        each do |props|
+          props[:is_dir] ? create_update_dir(props) : create_update_file(props)
+        end
     end
 
     def create_update_dir(props)

--- a/spec/services/dropbox/pull_service_spec.rb
+++ b/spec/services/dropbox/pull_service_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe Dropbox::PullService do
   it 'creates new files' do
     expect_delta(
       [
+        "/#{app.subdomain}",
+        {
+          'rev' => '0',
+          'path' => "/#{app.subdomain}",
+          'is_dir' => true
+        }
+      ], [
         "/#{app.subdomain}/file1.txt",
         {
           'rev' => '1',


### PR DESCRIPTION
Dropbox started to add root asked directory into delta entries. While converting this entry into relative path "" was returned which validate `AppMember` validation for path. To solve this issue this value is
filtered while creating or updating entries.