### PR TITLE
Fix cleaning Dropbox credentials while detaching application

### DIFF
--- a/app/services/dropbox/delete_service.rb
+++ b/app/services/dropbox/delete_service.rb
@@ -10,7 +10,7 @@ module Dropbox
     def execute
       delete_path
       app_member.dropbox_entries.destroy_all if app_member
-      clean_dropbox_account if has_dropbox_app?
+      clean_dropbox_account unless has_dropbox_app?
       clean_cursor
     end
 
@@ -25,7 +25,7 @@ module Dropbox
     def has_dropbox_app?
       author.apps.joins(:app_members).
         where(app_members: { dropbox_enabled: true }).
-        count
+        count > 0
     end
 
     def clean_dropbox_account

--- a/spec/services/dropbox/delete_service_spec.rb
+++ b/spec/services/dropbox/delete_service_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe Dropbox::DeleteService do
     expect(author.dropbox_user).to be_nil
   end
 
+  it 'does not clean dropbox account when other dropbox app exist' do
+    author.update_attributes(dropbox_access_token: 'token', dropbox_user: '123')
+    other_app = create(:app, users: [author], subdomain: 'other-app')
+    other_app_member = other_app.app_members.find_by(user: author)
+
+    other_app_member.update_attributes(dropbox_enabled: true)
+
+    service.execute
+    author.reload
+
+    expect(author.dropbox_access_token).to_not be_nil
+    expect(author.dropbox_user).to_not be_nil
+  end
+
   def expect_delete
     expect(client).
       to receive(:file_delete).


### PR DESCRIPTION
Dropbox credentials was always removed while detaching application from the Dropbox (even when other applications were connected). This PR fixes this issue.