### PR TITLE
Don't remove dropbox directory only rename

### DIFF
--- a/app/services/dropbox/delete_service.rb
+++ b/app/services/dropbox/delete_service.rb
@@ -17,7 +17,7 @@ module Dropbox
     private
 
     def delete_path
-      client.file_delete("/#{@subdomain}")
+      client.file_move("/#{@subdomain}", "/#{@subdomain} (detached)")
     rescue DropboxError => e
       raise e unless e.http_response.class == Net::HTTPNotFound
     end

--- a/spec/services/dropbox/delete_service_spec.rb
+++ b/spec/services/dropbox/delete_service_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Dropbox::DeleteService do
   let(:author) { create(:user) }
   let(:client) { instance_double('DropboxClient') }
 
-  before { allow(client).to receive(:file_delete) }
+  before { allow(client).to receive(:file_move) }
 
   it 'removes dropbox app directory' do
-    expect_delete
+    expect(client).
+      to receive(:file_move).
+      with('/subdomain-to-delete', '/subdomain-to-delete (detached)')
 
     service.execute
   end
@@ -61,12 +63,6 @@ RSpec.describe Dropbox::DeleteService do
 
     expect(author.dropbox_access_token).to_not be_nil
     expect(author.dropbox_user).to_not be_nil
-  end
-
-  def expect_delete
-    expect(client).
-      to receive(:file_delete).
-      with('/subdomain-to-delete')
   end
 
   def service


### PR DESCRIPTION
When user deletes application from plgapp or detach it from the dropbox then application dropbox directory is not deleted (as before) only its name is changed into "application_name (detached)".

Fixes #91