### PR TITLE
Move move Dropbox folder into delayed job

### DIFF
--- a/app/jobs/dropbox/move_job.rb
+++ b/app/jobs/dropbox/move_job.rb
@@ -1,0 +1,9 @@
+module Dropbox
+  class MoveJob < ActiveJob::Base
+    queue_as :dropbox
+
+    def perform(user, from, to)
+      Dropbox::MoveService.new(user, from, to).execute
+    end
+  end
+end

--- a/app/services/dropbox/move_service.rb
+++ b/app/services/dropbox/move_service.rb
@@ -2,11 +2,22 @@ module Dropbox
   class MoveService < Operation
     protected
 
-    def internal_execute
-      from = app.old_subdomain
-      to = app.subdomain
+    def initialize(author, from, to, options = {})
+      super(author, nil, options)
+      @from = from
+      @to = to
+    end
 
-      client.file_move(from, to) if from != to
+    def internal_execute
+      client.file_move(@from, @to) if path_changed?
+    rescue DropboxError
+      # source dir does not exist - do nothing
+    end
+
+    private
+
+    def path_changed?
+      @from != @to
     end
   end
 end

--- a/app/services/update_app_service.rb
+++ b/app/services/update_app_service.rb
@@ -17,7 +17,9 @@ class UpdateAppService < AppService
         if old_app_dir != new_app_dir
           FileUtils.mv(old_app_dir, new_app_dir)
           FileUtils.mv(app_dev_dir(app.old_subdomain), app_dev_dir(app))
-          dbox_app_users.each { |u| Dropbox::MoveService.new(u, app).execute }
+          dbox_app_users.each do |u|
+            Dropbox::MoveJob.perform_later(u, app.old_subdomain, app.subdomain)
+          end
         end
 
         if content_changed

--- a/spec/jobs/dropbox/move_job_spec.rb
+++ b/spec/jobs/dropbox/move_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Dropbox::MoveJob do
+  it 'rename dropbox file' do
+    user = double
+    service = instance_double(Dropbox::MoveService)
+    expect(service).to receive(:execute)
+
+    expect(Dropbox::MoveService).
+      to receive(:new).
+      with(user, 'from', 'to').
+      and_return(service)
+
+    subject.perform(user, 'from', 'to')
+  end
+end

--- a/spec/services/dropbox/move_service_spec.rb
+++ b/spec/services/dropbox/move_service_spec.rb
@@ -4,26 +4,25 @@ RSpec.describe Dropbox::MoveService do
   include DropboxHelper
 
   let(:author) { create(:user) }
-  let(:app) { create(:app, subdomain: 'from') }
   let(:client) { instance_double('DropboxClient') }
 
   context 'subdomain changed' do
     it 'rename app dropbox directory' do
+      service = described_class.new(author, 'from', 'to', client: client)
+
       expect(client).to receive(:file_move).with('from', 'to')
 
-      app.update_attributes(subdomain: 'to')
       service.execute
     end
   end
 
   context 'subdomain not changed' do
     it 'dont rename app dropbox directory' do
-      app.update_attributes(name: 'other name')
+      service = described_class.new(author, 'from', 'from', client: client)
+
+      expect(client).to_not receive(:file_move)
+
       service.execute
     end
-  end
-
-  def service
-    described_class.new(author, app, client: client)
   end
 end

--- a/spec/services/update_app_service_spec.rb
+++ b/spec/services/update_app_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UpdateAppService do
   include AppSpecHelper
 
   let(:author) { create(:user) }
-  let(:app) { build(:app) }
+  let(:app) { build(:app, subdomain: 'subdomain') }
 
   before { CreateAppService.new(author, app).execute }
   after { DestroyAppService.new(app).execute }
@@ -34,15 +34,14 @@ RSpec.describe UpdateAppService do
   end
 
   it 'rename dropbox dir when subdomain changed' do
-    params = { subdomain: 'new_subdomain' }
+    params = { subdomain: 'new-subdomain' }
     subject = UpdateAppService.new(author, app, params)
     app.app_members.find_by(user: author).
       update_attributes(dropbox_enabled: true)
 
-    expect(Dropbox::MoveService).
-      to receive(:new).
-      with(author, app).
-      and_return(double(execute: true))
+    expect(Dropbox::MoveJob).
+      to receive(:perform_later).
+      with(author, 'subdomain', 'new-subdomain')
 
     subject.execute
   end


### PR DESCRIPTION
Move Dropbox operation can be time a consuming job. That is why it was moved into delayed job.