### PR TITLE
Check for collision in Dropbox dir during first push

### DIFF
--- a/app/jobs/dropbox/push_job.rb
+++ b/app/jobs/dropbox/push_job.rb
@@ -3,6 +3,25 @@ module Dropbox
     queue_as :dropbox
 
     def perform(user, app)
+      check_for_conflict(user, app) if first_push?(user, app)
+      push(user, app)
+    end
+
+    private
+
+    def check_for_conflict(user, app)
+      Dropbox::MoveService.
+        new(user, app.subdomain,
+            "#{app.subdomain} (collision, moved at #{Time.now})").
+        execute
+    end
+
+    def first_push?(user, app)
+      app_member = app.app_members.find_by(user: user)
+      app_member && app_member.dropbox_entries.count == 0
+    end
+
+    def push(user, app)
       Dropbox::PushService.new(user, app).execute
     end
   end

--- a/spec/jobs/dropbox/push_job_spec.rb
+++ b/spec/jobs/dropbox/push_job_spec.rb
@@ -1,16 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe Dropbox::PushJob do
-  it 'add app to dropbox' do
-    user = double('user')
-    app = double('app')
-    service = instance_double(Dropbox::PushService)
-    expect(service).to receive(:execute)
+  let(:push_service) do
+    instance_double(Dropbox::PushService).tap do |service|
+      allow(service).to receive(:execute)
+    end
+  end
+  let(:move_service) do
+    instance_double(Dropbox::MoveService).tap do |service|
+      allow(service).to receive(:execute)
+    end
+  end
 
-    expect(Dropbox::PushService).
+  let(:user) { create(:user) }
+  let(:app) { create(:app, subdomain: 'subdomain', users: [user]) }
+
+  before do
+    allow(Dropbox::PushService).
       to receive(:new).
       with(user, app).
-      and_return(service)
+      and_return(push_service)
+
+    allow(Time).to receive(:now).
+      and_return(Time.utc(2015, 6, 17, 13, 3, 23))
+    allow(Dropbox::MoveService).
+      to receive(:new).
+      with(user, 'subdomain',
+          'subdomain (collision, moved at 2015-06-17 13:03:23 UTC)').
+      and_return(move_service)
+  end
+
+  it 'checks for dir collision and move if necessary on first push' do
+    expect(move_service).to receive(:execute)
+
+    subject.perform(user, app)
+  end
+
+  it 'don\'t check for collision after first push' do
+    app_member = app.app_members.find_by(user: user)
+    app_member.dropbox_entries.create(path: '/', is_dir: true)
+
+    expect(move_service).to_not receive(:execute)
+
+    subject.perform(user, app)
+  end
+
+  it 'add app to dropbox' do
+    expect(push_service).to receive(:execute)
 
     subject.perform(user, app)
   end


### PR DESCRIPTION
During first push we are checking if directory with app subdomain already exists. If yes than we are renaming it (adding comment with date).